### PR TITLE
Copy hidden files generated by appsody extract

### DIFF
--- a/setupAndRunExtract.sh
+++ b/setupAndRunExtract.sh
@@ -41,6 +41,5 @@ cd /workspace/$postfix
 ls -latr
 appsody extract -v
 # Copy the extracted contents to /workspace/extracted
-cp -rf /builder/home/.appsody/extract/$postfix/* /workspace/extracted/
+cp -rf /builder/home/.appsody/extract/$postfix/* /builder/home/.appsody/extract/$postfix/.[!.]* /workspace/extracted/
 ls -latr /workspace/extracted
-


### PR DESCRIPTION
For the `java-spring-boot2` stack, `appsody extract` generates a `.mvn-stack-settings.xml` which doesn't get copied to `/workspace/extracted` because hidden files don't match the * wildcard. This causes kaniko (possibly 🤔) to fail in the `build-and-push-step` [here](https://github.com/appsody/stacks/blob/master/incubator/java-spring-boot2/image/project/Dockerfile#L23).