### PR TITLE
Remove reference to tekton example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,3 @@ This repo includes a `.travis.yml` file that builds and pushes the image to Dock
 docker build -t appsody-docker -f Dockerfile .
 ```
 
-### Using the image
-An example of usage is provided by the [Appsody Tekton pipeline example](https://github.com/appsody/tekton-example). Check out the [Appsody build task](https://github.com/appsody/tekton-example/blob/master/appsody-build-task.yaml) manifest. 
-
-In that context, the image runs the `appsody extract` command to retrieve the entire project tree from the Appsody stack image and the application source tree hosted on GitHub.
-
-This image could be modified to run additional `appsody` commands if necessary.
-


### PR DESCRIPTION
We no longer use this image in the tekton-example repo, instead we now use the `appsody-buildah` image. However, we could detail other ways as to how a user could use this image.